### PR TITLE
Fix jest config to work with importing "app" code

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  moduleNameMapper: {
+    '^app/(.*)$': '<rootDir>/src/$1', // This should match what's in tsconfig.json
+  },
 };


### PR DESCRIPTION
Fix jest config to support importing `app` prefix.

Code like ```import { FileListMode } from "app/types/filesystem";```
should work now.